### PR TITLE
Fix for journal recovery with UPS_HINT_APPEND or UPS_HINT_PREPEND

### DIFF
--- a/src/3journal/journal.cc
+++ b/src/3journal/journal.cc
@@ -899,7 +899,7 @@ Journal::recover_journal(Context *context,
           txn = get_txn(txn_manager, entry.txn_id);
         db = get_db(entry.dbname);
         st = ups_db_insert((ups_db_t *)db, (ups_txn_t *)txn, 
-                    &key, &record, ins->insert_flags | UPS_DONT_LOCK);
+			&key, &record, ((ins->insert_flags | UPS_DONT_LOCK) & ~UPS_HINT_APPEND) & ~UPS_HINT_PREPEND);
         break;
       }
       case kEntryTypeErase: {


### PR DESCRIPTION
Bug: In journal recovery, when journal contains inserts that originated from a cursor with UPS_HINT_APPEND or UPS_HINT_PREPEND set, the error "flags UPS_HINT_APPEND/UPS_HINT_PREPEND is only allowed in ups_cursor_insert" is obtained.

Fix: In Journal::recover_journal, clear the flags UPS_HINT_APPEND and UPS_HINT_PREPEND when calling ups_db_insert.