### PR TITLE
Add NuGet package

### DIFF
--- a/dotnet/samples/SampleDb1/SampleDb1.csproj
+++ b/dotnet/samples/SampleDb1/SampleDb1.csproj
@@ -122,6 +122,10 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y ..\..\..\..\..\win32\msvc2013\out\dll_debug_x64\upscaledb-2.1.13.dll .\x64\
+xcopy /Y ..\..\..\..\..\win32\msvc2013\out\dll_debug\upscaledb-2.1.13.dll .\x86\</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/dotnet/samples/SampleEnv3/SampleEnv3.csproj
+++ b/dotnet/samples/SampleEnv3/SampleEnv3.csproj
@@ -122,6 +122,10 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y ..\..\..\..\..\win32\msvc2013\out\dll_debug_x64\upscaledb-2.1.13.dll .\x64\
+xcopy /Y ..\..\..\..\..\win32\msvc2013\out\dll_debug\upscaledb-2.1.13.dll .\x86\</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/dotnet/samples/SampleVb/SampleVb.vbproj
+++ b/dotnet/samples/SampleVb/SampleVb.vbproj
@@ -170,6 +170,10 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.VisualBasic.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy /Y ..\..\..\..\..\win32\msvc2013\out\dll_debug_x64\upscaledb-2.1.13.dll .\x64\
+xcopy /Y ..\..\..\..\..\win32\msvc2013\out\dll_debug\upscaledb-2.1.13.dll .\x86\</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/dotnet/unittests/Unittests.csproj
+++ b/dotnet/unittests/Unittests.csproj
@@ -106,7 +106,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Y ..\..\..\..\win32\msvc2013\out\dll_debug_x64\upscaledb-2.1.13.dll .</PostBuildEvent>
+    <PostBuildEvent>xcopy /Y ..\..\..\..\win32\msvc2013\out\dll_debug_x64\upscaledb-2.1.13.dll .\x64\
+xcopy /Y ..\..\..\..\win32\msvc2013\out\dll_debug\upscaledb-2.1.13.dll .\x86\</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/dotnet/upscaledb-dotnet/NativeMethods.cs
+++ b/dotnet/upscaledb-dotnet/NativeMethods.cs
@@ -23,10 +23,24 @@ using System.Runtime.CompilerServices;
 
 namespace Upscaledb
 {
-  internal sealed class NativeMethods
+  internal static class NativeMethods
   {
-    private NativeMethods() {
+    static NativeMethods() {
+        // Since managed assembly targets AnyCPU, at runtime we need to check which version of the native dll to load.
+        // This assumes that the native dlls are in subdirectories called x64 and x86, as is the case when using the NuGet package.
+        // See http://stackoverflow.com/questions/10852634/
+        var subdir = (IntPtr.Size == 8) ? "x64" : "x86";
+        if (System.IO.Directory.Exists(subdir)) {
+            LoadLibrary(subdir + "/upscaledb-2.1.13.dll");
+        }
+        else
+        {
+            // Legacy behaviour: assume native dll is in same directory as managed assembly
+        }
     }
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr LoadLibrary(string dllToLoad);
 
     [StructLayout(LayoutKind.Sequential)]
     unsafe struct RecordStruct

--- a/dotnet/upscaledb-dotnet/upscaledb-dotnet.csproj
+++ b/dotnet/upscaledb-dotnet/upscaledb-dotnet.csproj
@@ -137,6 +137,12 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>if $(ConfigurationName) == Release (
+if not exist nuget.exe powershell -Command "Invoke-WebRequest https://nuget.org/nuget.exe -OutFile nuget.exe"
+nuget.exe pack -Version 2.1.13 ..\..\upscaledb-dotnet.nuspec
+)</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/dotnet/upscaledb-dotnet/upscaledb-dotnet.nuspec
+++ b/dotnet/upscaledb-dotnet/upscaledb-dotnet.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>UpscaleDb-DotNet</id>
+    <version>$version$</version>
+    <authors>Christoph Rupp</authors>
+    <title>UpscaleDb</title>
+    <description>.NET class library for upscaledb</description>
+    <projectUrl>https://upscaledb.com/</projectUrl>
+    <licenseUrl>https://github.com/cruppstahl/upscaledb/blob/master/COPYING</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <copyright>Copyright © 2015 Christoph Rupp</copyright>
+    <tags>Embedded Database NoSQL</tags>
+    <references>
+      <reference file="UpscaleDb-dotnet.dll" />
+    </references>
+  </metadata>
+  <files>
+    <!-- Note: The name of the .targets file must match 'id' above -->
+    <file src="upscaledb-dotnet.targets" target="build" />
+    <file src="bin\Release\UpscaleDb-dotnet.*" exclude="**\*.nupkg" target="lib\net40" />
+    <file src="..\..\win32\msvc2013\out\dll\*.*" exclude="**\*.exp;**\*.lib" target="build\x86" />
+    <file src="..\..\win32\msvc2013\out\dll_x64\*.*" exclude="**\*.exp;**\*.lib" target="build\x64" />
+  </files>
+</package>

--- a/dotnet/upscaledb-dotnet/upscaledb-dotnet.targets
+++ b/dotnet/upscaledb-dotnet/upscaledb-dotnet.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!-- See http://stackoverflow.com/questions/19478775/ -->
+    <ItemGroup>
+        <NativeLibs Include="$(MSBuildThisFileDirectory)**\*.dll" />
+        <None Include="@(NativeLibs)">
+          <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <Visible>false</Visible>
+        </None>
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
* NativeMethods.cs: Added automatic loading of either x86 or x64 native dlls at runtime.  This assumes that the native dlls are in subdirectories called x64 and x86, as is the case when using the NuGet package.  If these directories are not present, then falls back on the existing behaviour where the appropriate native dll is assumed to be in the same directory as the managed assembly.
* Add upscaledb-dotnet.nuspec: Contains NuGet config to create package. The package is created in the bin\Release directory for a release build - see post build step in upscaledb-dotnet.csproj.
* Add upscaledb-dotnet.targets: This file is included in the NuGet package, and is automatically added to the .csproj file using the pacakge by NuGet. It is responsible for copying over the native dlls to the project output directory.
* Sample project files: added post build step to copy native dlls into output directory

Note: to update version number of NuGet package, update the -Version command line argument passed to nuget.exe in the post-build step in upscaledb-dotnet.csproj.