### PR TITLE
Fix build error on Mac

### DIFF
--- a/unittests/simd.cpp
+++ b/unittests/simd.cpp
@@ -21,6 +21,7 @@
 #include "3rdparty/catch/catch.hpp"
 
 #include "2simd/simd.h"
+#include <array>
 
 using namespace upscaledb;
 


### PR DESCRIPTION
I built on Mac. I have errors in the simd.cpp.
```
  CXX      simd.o
In file included from simd.cpp:23:
../src/2simd/simd.h:64:3: warning: 'register' storage class specifier is deprecated and incompatible
      with C++1z [-Wdeprecated-register]
  register uint32_t c = start;
  ^~~~~~~~~
../src/2simd/simd.h:164:5: warning: 'register' storage class specifier is deprecated and incompatible
      with C++1z [-Wdeprecated-register]
    register T d = data[i];
    ^~~~~~~~~
simd.cpp:31:20: error: implicit instantiation of undefined template 'std::__1::array<unsigned short,
      16>'
  std::array<T, S> values;
                   ^
```

So I changed simd.cpp. I was able to build on Mac.
Please check.