### PR TITLE
Add filesystem dependency

### DIFF
--- a/README
+++ b/README
@@ -105,6 +105,7 @@ On Ubuntu, the following packages are required:
   - libprotobuf-dev
   - libgoogle-perftools-dev
   - libboost-system-dev
+  - libboost-filesystem-dev
   - libboost-thread-dev
   - libboost-dev
 


### PR DESCRIPTION
Failing to install this before running the script results in a configuration error.

```
configure: error: cannot find the flags to link with Boost filesystem
```