### PR TITLE
fix compile error with gcc/10.2.1 and boost/1.71.0

### DIFF
--- a/src/5server/upsserver.cc
+++ b/src/5server/upsserver.cc
@@ -1973,7 +1973,7 @@ dispatch(Session *session, uint32_t magic, uint8_t *data, uint32_t size)
 void
 Session::handle_read(const boost::system::error_code &error,
                 size_t bytes_transferred) {
-  if (unlikely(error != 0) || bytes_transferred == 0) {
+  if (unlikely(error != boost::system::errc::errc_t::success) || bytes_transferred == 0) {
     delete this;
     return;
   }


### PR DESCRIPTION
```
upsserver.cc: In member function ‘void upscaledb::Session::handle_read(const boost::system::error_code&, size_t)’:
upsserver.cc:1976:22: error: no match for ‘operator!=’ (operand types are ‘const boost::system::error_code’ and ‘int’)
 1976 |   if (unlikely(error != 0) || bytes_transferred == 0) {
      |                ~~~~~ ^~ ~
      |                |        |
      |                |        int
      |                const boost::system::error_code
../0root/root.h:70:43: note: in definition of macro ‘unlikely’
   70 | #   define unlikely(x) __builtin_expect ((x), 0)
      |                                           ^
upsserver.cc:1976:22: note: candidate: ‘operator!=(int, int)’ (built-in)
 1976 |   if (unlikely(error != 0) || bytes_transferred == 0) {
      |                ~~~~~~^~~~
../0root/root.h:70:43: note: in definition of macro ‘unlikely’
   70 | #   define unlikely(x) __builtin_expect ((x), 0)
      |                                           ^
upsserver.cc:1976:22: note:   no known conversion for argument 1 from ‘const boost::system::error_code’ to ‘int’
 1976 |   if (unlikely(error != 0) || bytes_transferred == 0) {
      |                ~~~~~~^~~~
../0root/root.h:70:43: note: in definition of macro ‘unlikely’
   70 | #   define unlikely(x) __builtin_expect ((x), 0)
      |                                           ^
```