### PR TITLE
Fix compile for MSVC2013

### DIFF
--- a/src/2device/device_disk.h
+++ b/src/2device/device_disk.h
@@ -58,8 +58,29 @@ class DiskDevice : public Device {
       State(const State&) = delete;
       State& operator=(const State&) = delete;
       
-      State(State&&) = default;
-      State& operator=(State&& ) = default;
+#if defined(_MSC_VER)
+	  State(State&& rhs){
+		  file = std::move(rhs.file);
+		  mmapptr = rhs.mmapptr;
+		  mapped_size = rhs.mapped_size;
+		  file_size = rhs.file_size;
+		  excess_at_end = rhs.excess_at_end;
+	  }
+
+	  State& operator=(State&& rhs)
+	  {
+		  file = std::move(rhs.file);
+		  mmapptr = rhs.mmapptr;
+		  mapped_size = rhs.mapped_size;
+		  file_size = rhs.file_size;
+		  excess_at_end = rhs.excess_at_end;
+		  return *this;
+	  }
+#else
+	  State(State&&) = default;
+	  State& operator=(State&& ) = default;
+#endif
+
       // the database file
       File file;
 


### PR DESCRIPTION
Fix compile for MSVC2013 by explicitly implementing move constructor and operator which previously caused the compile error:

3>d:\upscaledb-fork\src\2device\device_disk.h(61): error C2610: 'upscaledb::DiskDevice::State::State(upscaledb::DiskDevice::State &&)' : is not a special member function which can be defaulted
3>d:\upscaledb-fork\src\2device\device_disk.h(62): error C2610: 'upscaledb::DiskDevice::State &upscaledb::DiskDevice::State::operator =(upscaledb::DiskDevice::State &&)' : is not a special member function which can be defaulted